### PR TITLE
fix: optimize docker dependency layer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.idea
+.tmp
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea/
+.tmp/
+dist/package.json
+dist/bun.lock
+dist/bun.lockb

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV ASDF_VERSION 0.10.2
 ENV PATH "/root/.asdf/shims:/root/.asdf/bin:$PATH"
 
 RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends curl tzdata
+    && apt-get -qq install -y --no-install-recommends curl tzdata \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY bash/ ./bash


### PR DESCRIPTION
## Customer Summary

- Keeps the reusable Docker utility image behavior the same while reducing package-manager residue in the built image.
- Narrows Docker build context inputs by excluding repository metadata and local/generated files.
- No migration or runtime changes are required.

## Technical Summary

- Cleans `/var/lib/apt/lists` in the same Docker layer that runs `apt-get update` and installs base packages.
- Adds `.dockerignore` entries for Git metadata, IDE files, temporary files, and `node_modules`.
- Adds `.gitignore` entries for `.tmp` and generated pruned package manifest/lockfile outputs.
- `@willbooster/wb` and pruned Node dependency installation changes are not applicable because this repository has no package manifest or lockfile.

## Why

- Cleaning apt indexes avoids carrying stale package index data in the image while preserving no-cache build correctness because update and install remain in one layer.
- The source copy already happens after dependency installation, so Docker layer caching for the dependency install step is preserved.

## Testing

- `bunx @willbooster-private/agent-workflows@1.19.4 skills check-pr-ci`
- `docker build -t docker-utils:optimize-dependencies .` blocked locally because the Docker daemon socket is unavailable at `/Users/exkazuu/.docker/run/docker.sock`.
